### PR TITLE
update bignum to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "./node_modules/mocha/bin/mocha test.js"
   },
   "dependencies": {
-    "bignum": "^0.9.2"
+    "bignum": "^0.11.0"
   },
   "devDependencies": {
     "mocha": "~1.18.2"


### PR DESCRIPTION
bignum 0.9.2 fails to build under iojs v3.3.0.  upgrading fixes the issue.

example:

```
> bignum@0.9.3 install /Volumes/alien/projects/boneskull/node-speke/node_modules/bignum
> node-gyp configure build

  CXX(target) Release/obj.target/bignum/bignum.o
In file included from ../bignum.cc:8:
../node_modules/nan/nan.h:261:25: error: redefinition of '_NanEnsureLocal'
NAN_INLINE v8::Local<T> _NanEnsureLocal(v8::Local<T> val) {
                        ^
../node_modules/nan/nan.h:256:25: note: previous definition is here
NAN_INLINE v8::Local<T> _NanEnsureLocal(v8::Handle<T> val) {
                        ^
../node_modules/nan/nan.h:661:13: error: no member named 'smalloc' in namespace 'node'
    , node::smalloc::FreeCallback callback
      ~~~~~~^
../node_modules/nan/nan.h:672:12: error: no matching function for call to 'New'
    return node::Buffer::New(v8::Isolate::GetCurrent(), data, size);
           ^~~~~~~~~~~~~~~~~
/Users/boneskull/.node-gyp/3.3.0/include/node/node_buffer.h:31:40: note: candidate function not viable: no known conversion from 'uint32_t' (aka 'unsigned int') to 'enum encoding' for 3rd argument
NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                       ^
/Users/boneskull/.node-gyp/3.3.0/include/node/node_buffer.h:43:40: note: candidate function not viable: 2nd argument ('const char *') would lose const qualifier
NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                       ^
/Users/boneskull/.node-gyp/3.3.0/include/node/node_buffer.h:28:40: note: candidate function not viable: requires 2 arguments, but 3 were provided
NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate, size_t length);
                                       ^
/Users/boneskull/.node-gyp/3.3.0/include/node/node_buffer.h:36:40: note: candidate function not viable: requires 5 arguments, but 3 were provided
NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                       ^
In file included from ../bignum.cc:8:
../node_modules/nan/nan.h:676:12: error: no viable conversion from 'v8::MaybeLocal<v8::Object>' to 'v8::Local<v8::Object>'
    return node::Buffer::New(v8::Isolate::GetCurrent(), size);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/boneskull/.node-gyp/3.3.0/include/node/v8.h:210:7: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'v8::MaybeLocal<v8::Object>' to 'const v8::Local<v8::Object> &' for 1st argument
class Local {
      ^
/Users/boneskull/.node-gyp/3.3.0/include/node/v8.h:210:7: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'v8::MaybeLocal<v8::Object>' to 'v8::Local<v8::Object> &&' for 1st argument
class Local {
      ^
/Users/boneskull/.node-gyp/3.3.0/include/node/v8.h:214:13: note: candidate template ignored: could not match 'Local' against 'MaybeLocal'
  V8_INLINE Local(Local<S> that)
            ^
/Users/boneskull/.node-gyp/3.3.0/include/node/v8.h:327:13: note: candidate template ignored: could not match 'S *' against 'v8::MaybeLocal<v8::Object>'
  V8_INLINE Local(S* that)
            ^
In file included from ../bignum.cc:8:
../node_modules/nan/nan.h:683:26: error: no member named 'Use' in namespace 'node::Buffer'
    return node::Buffer::Use(v8::Isolate::GetCurrent(), data, size);
           ~~~~~~~~~~~~~~^
In file included from ../bignum.cc:8:
In file included from ../node_modules/nan/nan.h:24:
In file included from /Users/boneskull/.node-gyp/3.3.0/include/node/node.h:42:
/Users/boneskull/.node-gyp/3.3.0/include/node/v8.h:221:5: error: assigning to 'v8::Primitive *volatile' from incompatible type 'v8::Value *'
    TYPE_CHECK(T, S);
    ^~~~~~~~~~~~~~~~
/Users/boneskull/.node-gyp/3.3.0/include/node/v8.h:180:37: note: expanded from macro 'TYPE_CHECK'
    *(static_cast<T* volatile*>(0)) = static_cast<S*>(0);      \
                                    ^ ~~~~~~~~~~~~~~~~~~
../node_modules/nan/nan.h:414:12: note: in instantiation of function template specialization 'v8::Local<v8::Primitive>::Local<v8::Value>' requested here
    return NanEscapeScope(NanNew(v8::Undefined(v8::Isolate::GetCurrent())));
           ^
../node_modules/nan/nan.h:398:30: note: expanded from macro 'NanEscapeScope'
# define NanEscapeScope(val) scope.Escape(_NanEnsureLocal(val))
                             ^
In file included from ../bignum.cc:8:
In file included from ../node_modules/nan/nan.h:24:
In file included from /Users/boneskull/.node-gyp/3.3.0/include/node/node.h:42:
/Users/boneskull/.node-gyp/3.3.0/include/node/v8.h:221:5: error: assigning to 'v8::Boolean *volatile' from incompatible type 'v8::Value *'
    TYPE_CHECK(T, S);
    ^~~~~~~~~~~~~~~~
/Users/boneskull/.node-gyp/3.3.0/include/node/v8.h:180:37: note: expanded from macro 'TYPE_CHECK'
    *(static_cast<T* volatile*>(0)) = static_cast<S*>(0);      \
                                    ^ ~~~~~~~~~~~~~~~~~~
../node_modules/nan/nan.h:424:12: note: in instantiation of function template specialization 'v8::Local<v8::Boolean>::Local<v8::Value>' requested here
    return NanEscapeScope(NanNew(v8::True(v8::Isolate::GetCurrent())));
           ^
../node_modules/nan/nan.h:398:30: note: expanded from macro 'NanEscapeScope'
# define NanEscapeScope(val) scope.Escape(_NanEnsureLocal(val))
                             ^
In file included from ../bignum.cc:8:
In file included from ../node_modules/nan/nan.h:24:
In file included from /Users/boneskull/.node-gyp/3.3.0/include/node/node.h:42:
/Users/boneskull/.node-gyp/3.3.0/include/node/v8.h:221:5: error: assigning to 'v8::Function *volatile' from incompatible type 'v8::Value *'
    TYPE_CHECK(T, S);
    ^~~~~~~~~~~~~~~~
/Users/boneskull/.node-gyp/3.3.0/include/node/v8.h:180:37: note: expanded from macro 'TYPE_CHECK'
    *(static_cast<T* volatile*>(0)) = static_cast<S*>(0);      \
                                    ^ ~~~~~~~~~~~~~~~~~~
../node_modules/nan/nan.h:1514:12: note: in instantiation of function template specialization 'v8::Local<v8::Function>::Local<v8::Value>' requested here
    return NanEscapeScope(NanNew(handle)->Get(kCallbackIndex)
           ^
../node_modules/nan/nan.h:398:30: note: expanded from macro 'NanEscapeScope'
# define NanEscapeScope(val) scope.Escape(_NanEnsureLocal(val))
                             ^
In file included from ../bignum.cc:8:
In file included from ../node_modules/nan/nan.h:24:
In file included from /Users/boneskull/.node-gyp/3.3.0/include/node/node.h:42:
/Users/boneskull/.node-gyp/3.3.0/include/node/v8.h:221:5: error: assigning to 'v8::Object *volatile' from incompatible type 'v8::Value *'
    TYPE_CHECK(T, S);
    ^~~~~~~~~~~~~~~~
/Users/boneskull/.node-gyp/3.3.0/include/node/v8.h:180:37: note: expanded from macro 'TYPE_CHECK'
    *(static_cast<T* volatile*>(0)) = static_cast<S*>(0);      \
                                    ^ ~~~~~~~~~~~~~~~~~~
../node_modules/nan/nan.h:1632:12: note: in instantiation of function template specialization 'v8::Local<v8::Object>::Local<v8::Value>' requested here
    return NanEscapeScope(handle->Get(NanNew(key)).As<v8::Object>());
           ^
../node_modules/nan/nan.h:398:30: note: expanded from macro 'NanEscapeScope'
# define NanEscapeScope(val) scope.Escape(_NanEnsureLocal(val))
                             ^
9 errors generated.
make: *** [Release/obj.target/bignum/bignum.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:269:23)
gyp ERR! stack     at emitTwo (events.js:87:13)
gyp ERR! stack     at ChildProcess.emit (events.js:172:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
gyp ERR! System Darwin 14.5.0
gyp ERR! command "/usr/local/bin/iojs" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "configure" "build"
gyp ERR! cwd /Volumes/alien/projects/boneskull/node-speke/node_modules/bignum
gyp ERR! node -v v3.3.0
gyp ERR! node-gyp -v v2.0.2
gyp ERR! not ok
npm ERR! Darwin 14.5.0
npm ERR! argv "/usr/local/bin/iojs" "/usr/local/bin/npm" "install"
npm ERR! node v3.3.0
npm ERR! npm  v2.13.3
npm ERR! code ELIFECYCLE

npm ERR! bignum@0.9.3 install: `node-gyp configure build`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the bignum@0.9.3 install script 'node-gyp configure build'.
npm ERR! This is most likely a problem with the bignum package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-gyp configure build
npm ERR! You can get their info via:
npm ERR!     npm owner ls bignum
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Volumes/alien/projects/boneskull/node-speke/npm-debug.log
```
